### PR TITLE
- fixed XOOPS version check on install

### DIFF
--- a/class/formtag.php
+++ b/class/formtag.php
@@ -54,7 +54,8 @@ class TagFormTag extends XoopsFormText
             }
         }
         $caption = _MD_TAG_TAGS;
-        $this->XoopsFormText($caption, $name, $size, $maxlength, $value);
+//        $this->XoopsFormText($caption, $name, $size, $maxlength, $value);
+        parent::__construct($caption, $name, $size, $maxlength, $value);
     }
 
     /**

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,8 @@
 2.33 RC 1         NOT RELEASED
 =================================
 - added check for plugins in /class/plugins (in preparation for next version of XOOPS (mamba)
+- fixed XOOPS version check on install (zyspec)
+- fixed call to XoopsFormText in TagFormTag class (zyspec)
 
 2.33 Beta 1       2014-12-05
 =================================

--- a/include/action.module.php
+++ b/include/action.module.php
@@ -37,14 +37,16 @@ function xoops_module_pre_install_tag(&$module)
     $success     = true;
     foreach ($reqArray as $k=>$v) {
         if (isset($currArray[$k])) {
-            if ($currArray[$k] >= $v) {
+            if ($currArray[$k] > $v) {
+                break;
+            } elseif ($currArray[$k] = $v) {
                 continue;
             } else {
                 $success = false;
                 break;
             }
         } else {
-            if ($v > 0) {
+            if (intval($v) > 0) { // to handle things like x.x.x.0_RC1
                 $success = false;
                 break;
             }
@@ -52,7 +54,6 @@ function xoops_module_pre_install_tag(&$module)
     }
     if (!$success) {
         $module->setErrors("This module requires XOOPS {$requiredVer}+ ({$currentVer} installed)");
-
         return false;
     }
 


### PR DESCRIPTION
- fixed call to XoopsFormText in TagFormTag class
